### PR TITLE
Suggested WOG fixes

### DIFF
--- a/runtime/include/Galaxy.h
+++ b/runtime/include/Galaxy.h
@@ -18,13 +18,13 @@ struct Galaxy
   /// Center of mass
   real4 getCenterOfMass() const;
 
-  /// Total Velocity
-  real4 getTotalVelocity() const;
+  /// Center-of-mass Velocity
+  real4 getCenterOfMassVelocity() const;
 
   /// Move center of mass to origin (0,0,0)
   void centering();
 
-  /// Remove total velocity
+  /// Remove center-of-mass velocity
   void steady();
 
   /// Move center of the galaxy

--- a/runtime/src/Galaxy.cpp
+++ b/runtime/src/Galaxy.cpp
@@ -28,17 +28,20 @@ real4 Galaxy::getCenterOfMass() const
 
 real4 Galaxy::getTotalVelocity() const
 {
+  real mass;
   real4 result = make_real4(0.0, 0.0, 0.0, 0.0);
-  for (auto const& v : vel)
+  for (int i = 0; i < vel.size(); i++)
   {
-    result.x += v.x;
-    result.y += v.y;
-    result.z += v.z;
+    mass = pos[i].w;
+    result.x += mass * vel[i].x;
+    result.y += mass * vel[i].y;
+    result.z += mass * vel[i].z;
+    result.w += mass;
   }
 
-  result.x /= vel.size();
-  result.y /= vel.size();
-  result.z /= vel.size();
+  result.x /= result.w;
+  result.y /= result.w;
+  result.z /= result.w;
   return result;
 }
 

--- a/runtime/src/Galaxy.cpp
+++ b/runtime/src/Galaxy.cpp
@@ -13,7 +13,7 @@ real4 Galaxy::getCenterOfMass() const
   real4 result = make_real4(0.0, 0.0, 0.0, 0.0);
   for (auto const& p : pos)
   {
-  	mass = p.w;
+    mass = p.w;
     result.x += mass * p.x;
     result.y += mass * p.y;
     result.z += mass * p.z;
@@ -26,7 +26,7 @@ real4 Galaxy::getCenterOfMass() const
   return result;
 }
 
-real4 Galaxy::getTotalVelocity() const
+real4 Galaxy::getCenterOfMassVelocity() const
 {
   real mass;
   real4 result = make_real4(0.0, 0.0, 0.0, 0.0);
@@ -58,12 +58,12 @@ void Galaxy::centering()
 
 void Galaxy::steady()
 {
-  real4 total_velocity = getTotalVelocity();
+  real4 center_of_mass_velocity = getCenterOfMassVelocity();
   for (auto &v : vel)
   {
-    v.x -= total_velocity.x;
-    v.y -= total_velocity.y;
-    v.z -= total_velocity.z;
+    v.x -= center_of_mass_velocity.x;
+    v.y -= center_of_mass_velocity.y;
+    v.z -= center_of_mass_velocity.z;
   }
 }
 

--- a/runtime/src/Galaxy.cpp
+++ b/runtime/src/Galaxy.cpp
@@ -30,7 +30,7 @@ real4 Galaxy::getCenterOfMassVelocity() const
 {
   real mass;
   real4 result = make_real4(0.0, 0.0, 0.0, 0.0);
-  for (int i = 0; i < vel.size(); i++)
+  for (size_t i = 0; i < vel.size(); i++)
   {
     mass = pos[i].w;
     result.x += mass * vel[i].x;

--- a/runtime/src/WOGManager.cpp
+++ b/runtime/src/WOGManager.cpp
@@ -79,34 +79,34 @@ void WOGManager::read_galaxies(std::string const& path)
 {
   for (int i = 0;; ++i)
   {
-  	std::string filename = path + "/galaxy_type_" + std::to_string(i) + ".tipsy";
-  	if (access(filename.c_str(), F_OK) == -1) break;
-  	std::cout << "Read file " << filename << " into GalaxyStore." << std::endl;
+	std::string filename = path + "/galaxy_type_" + std::to_string(i) + ".tipsy";
+	if (access(filename.c_str(), F_OK) == -1) break;
+	std::cout << "Read file " << filename << " into GalaxyStore." << std::endl;
 
-  	Galaxy galaxy;
-  	int Total2 = 0;
-  	int NFirst = 0;
-  	int NSecond = 0;
-  	int NThird = 0;
+	Galaxy galaxy;
+	int Total2 = 0;
+	int NFirst = 0;
+	int NSecond = 0;
+	int NThird = 0;
 
-  	read_tipsy_file_parallel(galaxy.pos, galaxy.vel, galaxy.ids,
-  	  0.0, filename.c_str(), 0, 1, Total2, NFirst, NSecond, NThird, nullptr,
-  	  galaxy.pos_dust, galaxy.vel_dust, galaxy.ids_dust, 1, 1, false);
+	read_tipsy_file_parallel(galaxy.pos, galaxy.vel, galaxy.ids,
+	  0.0, filename.c_str(), 0, 1, Total2, NFirst, NSecond, NThird, nullptr,
+	  galaxy.pos_dust, galaxy.vel_dust, galaxy.ids_dust, 1, 1, false);
 
-  	real4 cm = galaxy.getCenterOfMass();
-  	std::cout << "Center of mass = " << cm.x << " " << cm.y << " " << cm.z << std::endl;
-  	real4 tv = galaxy.getTotalVelocity();
-  	std::cout << "Total_velocity = " << tv.x << " " << tv.y << " " << tv.z << std::endl;
+	real4 cm = galaxy.getCenterOfMass();
+	std::cout << "Center of mass = " << cm.x << " " << cm.y << " " << cm.z << std::endl;
+	real4 tv = galaxy.getCenterOfMassVelocity();
+	std::cout << "Center_of_mass_velocity = " << tv.x << " " << tv.y << " " << tv.z << std::endl;
 
-  	galaxy.centering();
-  	galaxy.steady();
+	galaxy.centering();
+	galaxy.steady();
 
-  	cm = galaxy.getCenterOfMass();
-  	std::cout << "Center of mass = " << cm.x << " " << cm.y << " " << cm.z << std::endl;
-  	tv = galaxy.getTotalVelocity();
-  	std::cout << "Total_velocity = " << tv.x << " " << tv.y << " " << tv.z << std::endl;
+	cm = galaxy.getCenterOfMass();
+	std::cout << "Center of mass = " << cm.x << " " << cm.y << " " << cm.z << std::endl;
+	tv = galaxy.getCenterOfMassVelocity();
+	std::cout << "Center_of_mass_velocity = " << tv.x << " " << tv.y << " " << tv.z << std::endl;
 
-  	galaxies.push_back(galaxy);
+	galaxies.push_back(galaxy);
   }
 }
 

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -773,16 +773,18 @@ int main(int argc, char** argv, MPI_Comm comm, int shrMemPID)
       // get total velocity
       real4 total_velocity = make_real4(0.0, 0.0, 0.0, 0.0);
 
-      for (auto const& v : bodyVelocities)
+      for (int i = 0; i < bodyVelocities.size(); i++)
       {
-        total_velocity.x += v.x;
-        total_velocity.y += v.y;
-        total_velocity.z += v.z;
+        mass = bodyPositions[i].w;
+        total_velocity.x += mass * bodyVelocities[i].x;
+        total_velocity.y += mass * bodyVelocities[i].y;
+        total_velocity.z += mass * bodyVelocities[i].z;
+        total_velocity.w += mass;
       }
 
-      total_velocity.x /= bodyVelocities.size();
-      total_velocity.y /= bodyVelocities.size();
-      total_velocity.z /= bodyVelocities.size();
+      total_velocity.x /= total_velocity.w;
+      total_velocity.y /= total_velocity.w;
+      total_velocity.z /= total_velocity.w;
 
       // shift center of mass to position (0,0,10000)
       for (auto &p : bodyPositions)

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -759,32 +759,32 @@ int main(int argc, char** argv, MPI_Comm comm, int shrMemPID)
 
       for (auto const& p : bodyPositions)
       {
-      	mass = p.w;
-      	center_of_mass.x += mass * p.x;
-      	center_of_mass.y += mass * p.y;
-      	center_of_mass.z += mass * p.z;
-      	center_of_mass.w += mass;
+        mass = p.w;
+        center_of_mass.x += mass * p.x;
+        center_of_mass.y += mass * p.y;
+        center_of_mass.z += mass * p.z;
+        center_of_mass.w += mass;
       }
 
       center_of_mass.x /= center_of_mass.w;
       center_of_mass.y /= center_of_mass.w;
       center_of_mass.z /= center_of_mass.w;
 
-      // get total velocity
-      real4 total_velocity = make_real4(0.0, 0.0, 0.0, 0.0);
+      // get center-of-mass velocity
+      real4 center_of_mass_velocity = make_real4(0.0, 0.0, 0.0, 0.0);
 
       for (int i = 0; i < bodyVelocities.size(); i++)
       {
         mass = bodyPositions[i].w;
-        total_velocity.x += mass * bodyVelocities[i].x;
-        total_velocity.y += mass * bodyVelocities[i].y;
-        total_velocity.z += mass * bodyVelocities[i].z;
-        total_velocity.w += mass;
+        center_of_mass_velocity.x += mass * bodyVelocities[i].x;
+        center_of_mass_velocity.y += mass * bodyVelocities[i].y;
+        center_of_mass_velocity.z += mass * bodyVelocities[i].z;
+        center_of_mass_velocity.w += mass;
       }
 
-      total_velocity.x /= total_velocity.w;
-      total_velocity.y /= total_velocity.w;
-      total_velocity.z /= total_velocity.w;
+      center_of_mass_velocity.x /= center_of_mass_velocity.w;
+      center_of_mass_velocity.y /= center_of_mass_velocity.w;
+      center_of_mass_velocity.z /= center_of_mass_velocity.w;
 
       // shift center of mass to position (0,0,10000)
       for (auto &p : bodyPositions)
@@ -797,9 +797,9 @@ int main(int argc, char** argv, MPI_Comm comm, int shrMemPID)
       // steady
       for (auto &v : bodyVelocities)
       {
-        v.x -= total_velocity.x;
-        v.y -= total_velocity.y;
-        v.z -= total_velocity.z;
+        v.x -= center_of_mass_velocity.x;
+        v.y -= center_of_mass_velocity.y;
+        v.z -= center_of_mass_velocity.z;
       }
 #endif
     float sTime = 0;

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -773,7 +773,7 @@ int main(int argc, char** argv, MPI_Comm comm, int shrMemPID)
       // get center-of-mass velocity
       real4 center_of_mass_velocity = make_real4(0.0, 0.0, 0.0, 0.0);
 
-      for (int i = 0; i < bodyVelocities.size(); i++)
+      for (size_t i = 0; i < bodyVelocities.size(); i++)
       {
         mass = bodyPositions[i].w;
         center_of_mass_velocity.x += mass * bodyVelocities[i].x;

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -452,9 +452,9 @@ int main(int argc, char** argv, MPI_Comm comm, int shrMemPID)
 
 #ifdef WAR_OF_GALAXIES
     /// WarOfGalaxies: Deactivate unneeded flags using WarOfGalaxies
-    throw_if_flag_is_used(opt, {{"direct", "restart", "displayfps", "diskmode", "stereo", "prepend-rank"}});
-    throw_if_option_is_used(opt, {{"plummer", "milkyway", "mwfork", "sphere", "dt", "tend", "iend",
-      "snapname", "snapiter", "rmdist", "valueadd", "rebuild", "reducebodies", "reducedust", "gameMode"}});
+    throw_if_flag_is_used(opt, {{"direct", "restart", "diskmode", "stereo", "prepend-rank"}});
+    throw_if_option_is_used(opt, {{"plummer", "milkyway", "mwfork", "sphere", "tend", "iend",
+      "snapname", "snapiter", "rmdist", "valueadd", "rebuild", "reducedust", "gameMode"}});
 #endif
 
 #undef ADDUSAGE

--- a/tools/war-of-galaxies/README.md
+++ b/tools/war-of-galaxies/README.md
@@ -21,7 +21,7 @@ cmake \
   -DUSE_CUB=OFF \
   -DUSE_THRUST=ON \
   -DWAR_OF_GALAXIES=ON \
-  <source-path>
+  <source-path>/runtime/
 make -j <n>
 ```
 
@@ -38,7 +38,13 @@ Starting Bonsai with
 
 will show an empty simulation. In trues there is a single dummy particle at
 position (0,0,10000) with zero mass, because Bonsai can not run without any
-particles. The release or removal of galaxies will be controlled by json
+particles.
+
+Actual galaxies are located or symlinked in
+`<source-path>/tools/war-of-galaxies/galaxy_types/available`, with the naming
+scheme identifying the galaxy numbering.
+
+The release (insertion) or removal of galaxies will be controlled by json
 commands. Therefore, you can start the python script:
 
 ```


### PR DESCRIPTION
Hi,
few commits here that fix the calculation of a non-moving galaxy (calculation of "total_velocity"), plus renaming and minor docs update. Physically, the galaxy velocity needs to be computed by the velocity of the center of mass, not the average particle velocity because there are particles of different masses (although for our cases, the difference is fairly small).

I had, however, problems to run it (as I did with the original "war-of-galaxies" branch). It compiled, but didn't start up. Will investigate further.